### PR TITLE
Improve scalability of insertion in LIGGGHTS

### DIFF
--- a/examples/LIGGGHTS/Benchmarks/insert_pack/in.insertPack
+++ b/examples/LIGGGHTS/Benchmarks/insert_pack/in.insertPack
@@ -1,0 +1,62 @@
+#Contact model example
+
+atom_style	granular
+atom_modify	map array
+boundary	f f f
+newton		off
+
+communicate	single vel yes
+
+units		si
+
+region		reg block 0.0 0.5 0.0 0.5 0.0 0.5 units box
+create_box	1 reg
+
+neighbor	0.002 bin
+neigh_modify	delay 0
+modify_timing   on
+
+
+#Material properties required for new pair styles
+
+fix		m1 all property/global youngsModulus peratomtype 5.e6
+fix		m2 all property/global poissonsRatio peratomtype 0.45
+fix		m3 all property/global coefficientRestitution peratomtypepair 1 0.3
+fix		m4 all property/global coefficientFriction peratomtypepair 1 0.05
+fix		m5 all property/global characteristicVelocity scalar 2.
+
+
+#New pair style
+pair_style 	gran model hooke
+pair_coeff	* *
+
+timestep	0.00001
+
+fix		gravi all gravity 9.81 vector 0.0 0.0 -1.0
+
+fix		zwalls1 all wall/gran model hooke primitive type 1 xplane 0.0
+fix		zwalls2 all wall/gran model hooke primitive type 1 xplane 0.5
+fix		zwalls3 all wall/gran model hooke primitive type 1 yplane 0.0
+fix		zwalls4 all wall/gran model hooke primitive type 1 yplane 0.5
+fix		zwalls5 all wall/gran model hooke primitive type 1 zplane 0.0
+fix		zwalls6 all wall/gran model hooke primitive type 1 zplane 1.0
+
+#particle distributions
+fix		pts1 all particletemplate/sphere 1 atom_type 1 density constant 2500 radius constant 0.0025
+fix		pdd1 all particledistribution/discrete 1.  1 pts1 1.0
+
+
+#apply nve integration to all particles
+fix		integr all nve/sphere
+
+fix		ts all check/timestep/gran 1000 0.1 0.1
+
+#output settings, include total thermal energy
+compute		rke all erotate/sphere
+thermo_style	custom step atoms ke c_rke f_ts[1] f_ts[2] vol
+thermo		1000
+thermo_modify	lost ignore norm no
+compute_modify	thermo_temp dynamic yes
+
+fix ins all insert/pack seed 100001 distributiontemplate pdd1 vel constant 0. 0. 0. insert_every once overlapcheck yes all_in yes particles_in_region ${NPARTICLES} region reg
+run 1

--- a/examples/LIGGGHTS/Benchmarks/insert_pack/run.sh
+++ b/examples/LIGGGHTS/Benchmarks/insert_pack/run.sh
@@ -1,0 +1,10 @@
+#/bin/bash
+
+$LIGGGHTS_BINARY -in in.insertPack -var NPARTICLES 1000
+$LIGGGHTS_BINARY -in in.insertPack -var NPARTICLES 2000
+$LIGGGHTS_BINARY -in in.insertPack -var NPARTICLES 10000
+$LIGGGHTS_BINARY -in in.insertPack -var NPARTICLES 25000
+$LIGGGHTS_BINARY -in in.insertPack -var NPARTICLES 50000
+$LIGGGHTS_BINARY -in in.insertPack -var NPARTICLES 75000
+$LIGGGHTS_BINARY -in in.insertPack -var NPARTICLES 100000
+$LIGGGHTS_BINARY -in in.insertPack -var NPARTICLES 150000

--- a/src/bounding_box.cpp
+++ b/src/bounding_box.cpp
@@ -5,9 +5,9 @@
    LIGGGHTS is part of the CFDEMproject
    www.liggghts.com | www.cfdem.com
 
-   Christoph Kloss, christoph.kloss@cfdem.com
    Copyright 2009-2012 JKU Linz
-   Copyright 2012-     DCS Computing GmbH, Linz
+   Copyright 2012-2014 DCS Computing GmbH, Linz
+   Copyright 2015-     JKU Linz
 
    LIGGGHTS is based on LAMMPS
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
@@ -23,6 +23,7 @@
    Contributing authors:
    Christoph Kloss (JKU Linz, DCS Computing GmbH, Linz)
    Philippe Seil (JKU Linz)
+   Richard Berger (JKU Linz)
 ------------------------------------------------------------------------- */
 
 #include "bounding_box.h"
@@ -48,6 +49,26 @@ namespace LAMMPS_NS
     zLo = 0.; zHi = 0.;
     initGiven = false;
     dirty = true;
+  }
+
+  void BoundingBox::extendByDelta(double delta)
+  {
+    xLo = xLo-delta;
+    yLo = yLo-delta;
+    zLo = zLo-delta;
+    xHi = xHi+delta;
+    yHi = yHi+delta;
+    zHi = zHi+delta;
+  }
+
+  void BoundingBox::extrude(double length, const double * vec)
+  {
+    xLo = std::min(xLo, (xLo + length * vec[0]));
+    yLo = std::min(yLo, (yLo + length * vec[1]));
+    zLo = std::min(zLo, (zLo + length * vec[2]));
+    xHi = std::max(xHi, (xHi + length * vec[0]));
+    yHi = std::max(yHi, (yHi + length * vec[1]));
+    zHi = std::max(zHi, (zHi + length * vec[2]));
   }
 
 } /* namespace LAMMPS_NS */

--- a/src/bounding_box.h
+++ b/src/bounding_box.h
@@ -5,9 +5,9 @@
    LIGGGHTS is part of the CFDEMproject
    www.liggghts.com | www.cfdem.com
 
-   Christoph Kloss, christoph.kloss@cfdem.com
    Copyright 2009-2012 JKU Linz
-   Copyright 2012-     DCS Computing GmbH, Linz
+   Copyright 2012-2014 DCS Computing GmbH, Linz
+   Copyright 2015-     JKU Linz
 
    LIGGGHTS is based on LAMMPS
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
@@ -23,6 +23,7 @@
    Contributing authors:
    Christoph Kloss (JKU Linz, DCS Computing GmbH, Linz)
    Philippe Seil (JKU Linz)
+   Richard Berger (JKU Linz)
 ------------------------------------------------------------------------- */
 
 #ifndef LMP_BOUNDING_BOX
@@ -83,42 +84,53 @@ class BoundingBox
       zLo = -limit[4];
       zHi =  limit[5];
     }
+
+    void extrude(double length, const double * vec);
+
     void getBoxBounds(double *lo,double *hi)
     {
-        lo[0] = xLo;
-        lo[1] = yLo;
-        lo[2] = zLo;
-        hi[0] = xHi;
-        hi[1] = yHi;
-        hi[2] = zHi;
+      lo[0] = xLo;
+      lo[1] = yLo;
+      lo[2] = zLo;
+      hi[0] = xHi;
+      hi[1] = yHi;
+      hi[2] = zHi;
     }
+
+    void getExtent(double extent[3]) const {
+      extent[0] = xHi - xLo;
+      extent[1] = yHi - yLo;
+      extent[2] = zHi - zLo;
+    }
+
+    void extendByDelta(double delta);
 
     void getBoxBoundsExtendedByDelta(double *lo,double *hi,double delta)
     {
-        lo[0] = xLo-delta;
-        lo[1] = yLo-delta;
-        lo[2] = zLo-delta;
-        hi[0] = xHi+delta;
-        hi[1] = yHi+delta;
-        hi[2] = zHi+delta;
+      lo[0] = xLo-delta;
+      lo[1] = yLo-delta;
+      lo[2] = zLo-delta;
+      hi[0] = xHi+delta;
+      hi[1] = yHi+delta;
+      hi[2] = zHi+delta;
     }
 
     void shrinkToSubbox(double *sublo,double *subhi)
     {
-        if(xLo < sublo[0])
-            xLo = sublo[0];
-        if(xHi > subhi[0])
-            xHi = subhi[0];
+      if(xLo < sublo[0])
+          xLo = sublo[0];
+      if(xHi > subhi[0])
+          xHi = subhi[0];
 
-        if(yLo < sublo[1])
-            yLo = sublo[1];
-        if(yHi > subhi[1])
-            yHi = subhi[1];
+      if(yLo < sublo[1])
+          yLo = sublo[1];
+      if(yHi > subhi[1])
+          yHi = subhi[1];
 
-        if(zLo < sublo[2])
-            zLo = sublo[2];
-        if(zHi > subhi[2])
-            zHi = subhi[2];
+      if(zLo < sublo[2])
+          zLo = sublo[2];
+      if(zHi > subhi[2])
+          zHi = subhi[2];
     }
 
     bool isInitialized()
@@ -128,11 +140,9 @@ class BoundingBox
     {
        // check bbox
        // test for >= and < as in Domain class
-        if (p[0] >= xLo && p[0] < xHi &&
-            p[1] >= yLo && p[1] < yHi &&
-            p[2] >= zLo && p[2] < zHi)
-            return true;
-        return false;
+       return (p[0] >= xLo && p[0] < xHi &&
+           p[1] >= yLo && p[1] < yHi &&
+           p[2] >= zLo && p[2] < zHi);
     }
 
     bool isDirty() const {
@@ -144,9 +154,7 @@ class BoundingBox
     }
 
   private:
-
     double xLo, xHi, yLo, yHi, zLo, zHi;
-
     bool initGiven;
     bool dirty;
 };

--- a/src/fix_insert.h
+++ b/src/fix_insert.h
@@ -5,9 +5,9 @@
    LIGGGHTS is part of the CFDEMproject
    www.liggghts.com | www.cfdem.com
 
-   Christoph Kloss, christoph.kloss@cfdem.com
    Copyright 2009-2012 JKU Linz
-   Copyright 2012-     DCS Computing GmbH, Linz
+   Copyright 2012-2014 DCS Computing GmbH, Linz
+   Copyright 2015-     JKU Linz
 
    LIGGGHTS is based on LAMMPS
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
@@ -19,6 +19,12 @@
    See the README file in the top-level directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   Contributing authors:
+   Christoph Kloss (JKU Linz, DCS Computing GmbH, Linz)
+   Richard Berger (JKU Linz)
+------------------------------------------------------------------------- */
+
 #ifdef FIX_CLASS
 
 #else
@@ -27,6 +33,8 @@
 #define LMP_FIX_INSERT_H
 
 #include "fix.h"
+#include "bounding_box.h"
+#include "region_neighbor_list.h"
 
 namespace LAMMPS_NS {
 
@@ -50,9 +58,9 @@ class FixInsert : public Fix {
 
   double compute_vector(int index);
 
-  virtual double min_rad(int);  
-  virtual double max_rad(int);  
-  virtual double max_r_bound();  
+  virtual double min_rad(int);
+  virtual double max_rad(int);
+  virtual double max_r_bound();
   int min_type();
   int max_type();
 
@@ -122,8 +130,7 @@ class FixInsert : public Fix {
   int maxattempt;
 
   // positions generated, and for overlap check
-  int nspheres_near;
-  double **xnear;
+  LIGGGHTS::RegionNeighborList neighList;
 
   // velocity and ang vel distribution
   // currently constant for omega - could also be a distribution
@@ -165,11 +172,15 @@ class FixInsert : public Fix {
   virtual int load_xnear(int);
   virtual int count_nnear();
   virtual int is_nearby(int) = 0;
+  virtual BoundingBox getBoundingBox() const = 0;
 
   virtual void x_v_omega(int,int&,int&,double&) = 0;
   virtual double insertion_fraction() = 0;
 
   virtual void finalize_insertion(int){};
+
+ protected:
+  void generate_random_velocity(double * velocity);
 
  private:
 

--- a/src/fix_insert_pack.h
+++ b/src/fix_insert_pack.h
@@ -5,9 +5,9 @@
    LIGGGHTS is part of the CFDEMproject
    www.liggghts.com | www.cfdem.com
 
-   Christoph Kloss, christoph.kloss@cfdem.com
    Copyright 2009-2012 JKU Linz
-   Copyright 2012-     DCS Computing GmbH, Linz
+   Copyright 2012-2014 DCS Computing GmbH, Linz
+   Copyright 2015-     JKU Linz
 
    LIGGGHTS is based on LAMMPS
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
@@ -17,6 +17,12 @@
    This software is distributed under the GNU General Public License.
 
    See the README file in the top-level directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors:
+   Christoph Kloss (JKU Linz, DCS Computing GmbH, Linz)
+   Richard Berger (JKU Linz)
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS
@@ -54,6 +60,7 @@ class FixInsertPack : public FixInsert {
 
   int is_nearby(int);
   int is_nearby_body(int);
+  virtual BoundingBox getBoundingBox() const;
 
   // region to be used for insertion
   class Region *ins_region;

--- a/src/fix_insert_stream.cpp
+++ b/src/fix_insert_stream.cpp
@@ -5,9 +5,9 @@
    LIGGGHTS is part of the CFDEMproject
    www.liggghts.com | www.cfdem.com
 
-   Christoph Kloss, christoph.kloss@cfdem.com
    Copyright 2009-2012 JKU Linz
-   Copyright 2012-     DCS Computing GmbH, Linz
+   Copyright 2012-2014 DCS Computing GmbH, Linz
+   Copyright 2015-     JKU Linz
 
    LIGGGHTS is based on LAMMPS
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
@@ -17,6 +17,12 @@
    This software is distributed under the GNU General Public License.
 
    See the README file in the top-level directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors:
+   Christoph Kloss (JKU Linz, DCS Computing GmbH, Linz)
+   Richard Berger (JKU Linz)
 ------------------------------------------------------------------------- */
 
 #include "math.h"
@@ -354,7 +360,7 @@ void FixInsertStream::init()
     
     FixInsert::init();
 
-    if(fix_multisphere && v_randomSetting != 0)
+    if(fix_multisphere && v_randomSetting != RANDOM_CONSTANT)
         error->fix_error(FLERR,this,"Currently only fix insert/stream with multisphere particles only supports constant velocity");
 
     fix_release = static_cast<FixPropertyAtom*>(modify->find_fix_property("release_fix_insert_stream","property/atom","vector",5,0,style));
@@ -497,6 +503,18 @@ inline int FixInsertStream::is_nearby(int i)
     return ins_face->isOnSurface(pos_projected);
 }
 
+BoundingBox FixInsertStream::getBoundingBox() const {
+  BoundingBox bb = ins_face->getGlobalBoundingBox();
+
+  const double cut = 3*maxrad;
+  bb.extendByDelta(cut);
+
+  const double delta = -(extrude_length + 2*cut);
+  bb.extrude(delta, normalvec);
+  bb.shrinkToSubbox(domain->sublo, domain->subhi);
+  return bb;
+}
+
 /* ----------------------------------------------------------------------
    generate random positions on insertion face
    extrude by random length in negative face normal direction
@@ -628,8 +646,7 @@ void FixInsertStream::x_v_omega(int ninsert_this_local,int &ninserted_this_local
                 
                 if(ntry < maxtry)
                 {
-                    
-                    nins = pti->check_near_set_x_v_omega(pos,v_normal,omega_tmp,quat_insert,xnear,nspheres_near);
+                    nins = pti->check_near_set_x_v_omega(pos,v_normal,omega_tmp,quat_insert,neighList);
                 }
             }
 
@@ -696,18 +713,7 @@ void FixInsertStream::finalize_insertion(int ninserted_spheres_this_local)
         vectorCopy3D(omega_insert,omega_toInsert);
 
         // could ramdonize vel, omega, quat here
-        if(v_randomSetting==1)
-        {
-            v_toInsert[0] = v_insert[0] + v_insertFluct[0] * 2.0 * (random->uniform()-0.50);
-            v_toInsert[1] = v_insert[1] + v_insertFluct[1] * 2.0 * (random->uniform()-0.50);
-            v_toInsert[2] = v_insert[2] + v_insertFluct[2] * 2.0 * (random->uniform()-0.50);
-        }
-        else if(v_randomSetting==2)
-        {
-            v_toInsert[0] = v_insert[0] + v_insertFluct[0] * random->gaussian();
-            v_toInsert[1] = v_insert[1] + v_insertFluct[1] * random->gaussian();
-            v_toInsert[2] = v_insert[2] + v_insertFluct[2] * random->gaussian();
-        }
+        generate_random_velocity(v_toInsert);
 
         // 9-11th value is velocity, 12-14 is omega
         vectorCopy3D(v_toInsert,&release_data[i][8]);

--- a/src/fix_insert_stream.h
+++ b/src/fix_insert_stream.h
@@ -5,9 +5,9 @@
    LIGGGHTS is part of the CFDEMproject
    www.liggghts.com | www.cfdem.com
 
-   Christoph Kloss, christoph.kloss@cfdem.com
    Copyright 2009-2012 JKU Linz
-   Copyright 2012-     DCS Computing GmbH, Linz
+   Copyright 2012-2014 DCS Computing GmbH, Linz
+   Copyright 2015-     JKU Linz
 
    LIGGGHTS is based on LAMMPS
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
@@ -19,6 +19,12 @@
    See the README file in the top-level directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   Contributing authors:
+   Christoph Kloss (JKU Linz, DCS Computing GmbH, Linz)
+   Richard Berger (JKU Linz)
+------------------------------------------------------------------------- */
+
 #ifdef FIX_CLASS
 
 FixStyle(insert/stream,FixInsertStream)
@@ -28,6 +34,7 @@ FixStyle(insert/stream,FixInsertStream)
 #ifndef LMP_FIX_INSERT_STREAM_H
 #define LMP_FIX_INSERT_STREAM_H
 
+#include "bounding_box.h"
 #include "fix_insert.h"
 
 namespace LAMMPS_NS {
@@ -65,6 +72,8 @@ class FixInsertStream : public FixInsert {
   void pre_insert();
 
   int is_nearby(int);
+  virtual BoundingBox getBoundingBox() const;
+
   inline void generate_random(double *pos, double rad);
   inline void generate_random_global(double *pos);
 

--- a/src/particleToInsert.cpp
+++ b/src/particleToInsert.cpp
@@ -5,9 +5,9 @@
    LIGGGHTS is part of the CFDEMproject
    www.liggghts.com | www.cfdem.com
 
-   Christoph Kloss, christoph.kloss@cfdem.com
    Copyright 2009-2012 JKU Linz
-   Copyright 2012-     DCS Computing GmbH, Linz
+   Copyright 2012-2014 DCS Computing GmbH, Linz
+   Copyright 2015-     JKU Linz
 
    LIGGGHTS is based on LAMMPS
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
@@ -17,6 +17,12 @@
    This software is distributed under the GNU General Public License.
 
    See the README file in the top-level directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors:
+   Christoph Kloss (JKU Linz, DCS Computing GmbH, Linz)
+   Richard Berger (JKU Linz)
 ------------------------------------------------------------------------- */
 
 #include "particleToInsert.h"
@@ -115,6 +121,24 @@ int ParticleToInsert::check_near_set_x_v_omega(double *x,double *v, double *omeg
     vectorCopy3D(x_ins[0],xnear[nnear]);
     xnear[nnear][3] = radius_ins[0];
     nnear++;
+
+    return 1;
+}
+
+int ParticleToInsert::check_near_set_x_v_omega(double *x,double *v, double *omega, double *quat, LIGGGHTS::RegionNeighborList & neighList)
+{
+    vectorCopy3D(x,x_ins[0]);
+
+    if(neighList.hasOverlap(x_ins[0], radius_ins[0])) {
+        return 0;
+    }
+
+    // no overlap with any other - success
+
+    vectorCopy3D(v,v_ins);
+    vectorCopy3D(omega,omega_ins);
+
+    neighList.insert(x_ins[0], radius_ins[0]);
 
     return 1;
 }

--- a/src/particleToInsert.h
+++ b/src/particleToInsert.h
@@ -5,9 +5,9 @@
    LIGGGHTS is part of the CFDEMproject
    www.liggghts.com | www.cfdem.com
 
-   Christoph Kloss, christoph.kloss@cfdem.com
    Copyright 2009-2012 JKU Linz
-   Copyright 2012-     DCS Computing GmbH, Linz
+   Copyright 2012-2014 DCS Computing GmbH, Linz
+   Copyright 2015-     JKU Linz
 
    LIGGGHTS is based on LAMMPS
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
@@ -19,11 +19,18 @@
    See the README file in the top-level directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   Contributing authors:
+   Christoph Kloss (JKU Linz, DCS Computing GmbH, Linz)
+   Richard Berger (JKU Linz)
+------------------------------------------------------------------------- */
+
 #ifndef LMP_PARTICLE_TO_INSERT_H
 #define LMP_PARTICLE_TO_INSERT_H
 
 #include "memory.h"
 #include "pointers.h"
+#include "region_neighbor_list.h"
 
 using namespace LAMMPS_NS;
 
@@ -56,6 +63,7 @@ namespace LAMMPS_NS {
 
         virtual int insert();
         virtual int check_near_set_x_v_omega(double *x,double *v, double *omega, double *quat, double **xnear, int &nnear);
+        virtual int check_near_set_x_v_omega(double *x,double *v, double *omega, double *quat, LIGGGHTS::RegionNeighborList & neighList);
         virtual int set_x_v_omega(double *,double *,double *,double *);
 
         virtual void scale_pti(double r_scale);

--- a/src/region_neighbor_list.cpp
+++ b/src/region_neighbor_list.cpp
@@ -1,0 +1,288 @@
+/* ----------------------------------------------------------------------
+   LIGGGHTS - LAMMPS Improved for General Granular and Granular Heat
+   Transfer Simulations
+
+   Copyright 2014-     JKU Linz
+
+   LIGGGHTS is based on LAMMPS
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author:
+   Richard Berger (JKU Linz)
+------------------------------------------------------------------------- */
+
+#include "lmptype.h"
+#include "mpi.h"
+#include "bounding_box.h"
+#include "region_neighbor_list.h"
+#include <limits>
+#include "assert.h"
+
+static const double SMALL = 1.0e-6;
+static const double BIG = 1.0e20;
+
+using namespace LAMMPS_NS;
+using namespace LIGGGHTS;
+using namespace std;
+
+
+/**
+ * @brief Default constructor which will create an empty neighbor list
+ */
+RegionNeighborList::RegionNeighborList() {
+}
+
+
+/**
+ * @brief Determine if the given particle overlaps with any particle in this neighbor list
+ * @param x        position of particle to check
+ * @param radius   radius of particle to check
+ * @return true if particle has an overlap with a particle in this neighbor list, false otherwise
+ */
+bool RegionNeighborList::hasOverlap(double * x, double radius) const {
+  int ibin = coord2bin(x);
+
+  for(std::vector<int>::const_iterator it = stencil.begin(); it != stencil.end(); ++it) {
+    const int offset = *it;
+    assert(ibin+offset >= 0 || (size_t)(ibin+offset) < bins.size());
+    const ParticleBin & bin = bins[ibin+offset];
+
+    for(ParticleBin::const_iterator pit = bin.begin(); pit != bin.end(); ++pit) {
+      const Particle & p = *pit;
+      double del[3];
+      vectorSubtract3D(x, p.x, del);
+      const double rsq = vectorMag3DSquared(del);
+      const double radsum = radius + p.radius;
+      if (rsq <= radsum*radsum) return true;
+    }
+  }
+
+  return false;
+}
+
+
+/**
+ * @brief Insert a new particle into neighbor list
+ * @param x        position in 3D
+ * @param radius   particle radius
+ */
+void RegionNeighborList::insert(double * x, double radius) {
+  int ibin = coord2bin(x);
+  assert(ibin >= 0 && ibin <= bins.size());
+
+  bins[ibin].push_back(Particle(x, radius));
+  ++ncount;
+}
+
+
+/**
+ * @brief Clears neighbor list and brings it into initial state
+ */
+void RegionNeighborList::reset() {
+  bins.clear();
+  stencil.clear();
+  ncount = 0;
+}
+
+
+/**
+ * @brief Returns the number of particles inserted into the neighbor list
+ * @return number of particles in neighbor list
+ */
+size_t RegionNeighborList::count() const {
+  return ncount;
+}
+
+
+/**
+ * @brief Update the region bounding box
+ *
+ * This will update internal data structures to ensure they can handle the new
+ * region, which is defined by its bounding box.
+ *
+ * @param bb        bounding box of region
+ * @param maxrad    largest particle radius
+ * @return true if bounding box was set successfully, false bounding box could not
+ * be set and neighbor list is not usable
+ */
+bool RegionNeighborList::setBoundingBox(BoundingBox & bb, double maxrad) {
+  double extent[3];
+  bb.getExtent(extent);
+
+  if(extent[0] <= 0.0 || extent[1] <= 0.0 || extent[2] <= 0.0) {
+    // empty or invalid region
+    bins.clear();
+    stencil.clear();
+    return false;
+  }
+
+  bb.getBoxBounds(bboxlo, bboxhi);
+
+  // testing code
+  double binsize_optimal = 4*maxrad;
+  double binsizeinv = 1.0/binsize_optimal;
+
+  // test for too many global bins in any dimension due to huge global domain
+  const int max_small_int = std::numeric_limits<int>::max();
+
+  if (extent[0]*binsizeinv > max_small_int || extent[1]*binsizeinv > max_small_int ||
+      extent[2]*binsizeinv > max_small_int) {
+    printf("ERROR: too many bins for this domain\n");
+    return false;
+  }
+
+  // create actual bins
+  nbinx = static_cast<int>(extent[0]*binsizeinv);
+  nbiny = static_cast<int>(extent[1]*binsizeinv);
+  nbinz = static_cast<int>(extent[2]*binsizeinv);
+
+  if (nbinx == 0) nbinx = 1;
+  if (nbiny == 0) nbiny = 1;
+  if (nbinz == 0) nbinz = 1;
+
+  binsizex = extent[0]/nbinx;
+  binsizey = extent[1]/nbiny;
+  binsizez = extent[2]/nbinz;
+
+  bininvx = 1.0 / binsizex;
+  bininvy = 1.0 / binsizey;
+  bininvz = 1.0 / binsizez;
+
+  // mbinlo/hi = lowest and highest global bins my ghost atoms could be in
+  // coord = lowest and highest values of coords for my ghost atoms
+  // static_cast(-1.5) = -1, so subract additional -1
+  // add in SMALL for round-off safety
+
+  double bsubboxlo[3], bsubboxhi[3];
+  bb.getBoxBounds(bsubboxlo, bsubboxhi);
+
+  double coord = bsubboxlo[0] - SMALL*extent[0];
+  mbinxlo = static_cast<int> ((coord-bboxlo[0])*bininvx);
+  if (coord < bboxlo[0]) mbinxlo = mbinxlo - 1;
+  coord = bsubboxhi[0] + SMALL*extent[0];
+  int mbinxhi = static_cast<int> ((coord-bboxlo[0])*bininvx);
+
+  coord = bsubboxlo[1] - SMALL*extent[1];
+  mbinylo = static_cast<int> ((coord-bboxlo[1])*bininvy);
+  if (coord < bboxlo[1]) mbinylo = mbinylo - 1;
+  coord = bsubboxhi[1] + SMALL*extent[1];
+  int mbinyhi = static_cast<int> ((coord-bboxlo[1])*bininvy);
+
+  coord = bsubboxlo[2] - SMALL*extent[2];
+  mbinzlo = static_cast<int> ((coord-bboxlo[2])*bininvz);
+  if (coord < bboxlo[2]) mbinzlo = mbinzlo - 1;
+  coord = bsubboxhi[2] + SMALL*extent[2];
+  int mbinzhi = static_cast<int> ((coord-bboxlo[2])*bininvz);
+
+  // extend bins by 1 to insure stencil extent is included
+
+  mbinxlo = mbinxlo - 1;
+  mbinxhi = mbinxhi + 1;
+  mbinylo = mbinylo - 1;
+  mbinyhi = mbinyhi + 1;
+  mbinzlo = mbinzlo - 1;
+  mbinzhi = mbinzhi + 1;
+
+  mbinx = mbinxhi - mbinxlo + 1;
+  mbiny = mbinyhi - mbinylo + 1;
+  mbinz = mbinzhi - mbinzlo + 1;
+
+#ifdef LIGGGHTS_DEBUG
+  printf("setting insertion bounding box: [%g, %g] x [%g, %g] x [%g, %g]\n", bsubboxlo[0], bsubboxhi[0], bsubboxlo[1], bsubboxhi[1], bsubboxlo[2], bsubboxhi[2]);
+  printf("nbinx %d nbiny %d, nbinz %d\n",nbinx,nbiny,nbinz);
+  printf("mbinxlo: %d, mbinxhi: %d\n", mbinxlo, mbinxhi);
+  printf("mbinylo: %d, mbinyhi: %d\n", mbinylo, mbinyhi);
+  printf("mbinzlo: %d, mbinzhi: %d\n", mbinzlo, mbinzhi);
+  printf("mbinx %d mbiny %d, mbinz %d\n",mbinx,mbiny,mbinz);
+#endif
+
+  // allocate bins
+  bigint bbin = ((bigint) mbinx) * ((bigint) mbiny) * ((bigint) mbinz);
+  if (bbin > max_small_int) {
+    printf("ERROR: Too many neighbor bins\n");
+    return false;
+  }
+  bins.resize(bbin);
+
+  // generate stencil which will look at all bins 27 bins
+  for (int k = -1; k <= 1; k++)
+    for (int j = -1; j <= 1; j++)
+      for (int i = -1; i <= 1; i++)
+        stencil.push_back(k*mbiny*mbinx + j*mbinx + i);
+
+  return true;
+}
+
+/**
+ * @brief Compute the closest distance between central bin (0,0,0) and bin (i,j,k)
+ * @param i bin coordinate along x-axis
+ * @param j bin coordinate along y-axis
+ * @param k bin coordinate along z-axis
+ * @return closest distance between central bin (0,0,0) and bin (i,j,k)
+ */
+double RegionNeighborList::bin_distance(int i, int j, int k)
+{
+  double delx,dely,delz;
+
+  if (i > 0) delx = (i-1)*binsizex;
+  else if (i == 0) delx = 0.0;
+  else delx = (i+1)*binsizex;
+
+  if (j > 0) dely = (j-1)*binsizey;
+  else if (j == 0) dely = 0.0;
+  else dely = (j+1)*binsizey;
+
+  if (k > 0) delz = (k-1)*binsizez;
+  else if (k == 0) delz = 0.0;
+  else delz = (k+1)*binsizez;
+
+  return (delx*delx + dely*dely + delz*delz);
+}
+
+
+/**
+ * @brief Determine the bin index of a given point x
+ * @param x point in 3D
+ * @return bin index of the given point x
+ */
+int RegionNeighborList::coord2bin(double *x) const
+{
+  int ix,iy,iz;
+
+  if (x[0] >= bboxhi[0])
+    ix = static_cast<int> ((x[0]-bboxhi[0])*bininvx) + nbinx;
+  else if (x[0] >= bboxlo[0]) {
+    ix = static_cast<int> ((x[0]-bboxlo[0])*bininvx);
+    ix = std::min(ix,nbinx-1);
+  } else
+    ix = static_cast<int> ((x[0]-bboxlo[0])*bininvx) - 1;
+
+  if (x[1] >= bboxhi[1])
+    iy = static_cast<int> ((x[1]-bboxhi[1])*bininvy) + nbiny;
+  else if (x[1] >= bboxlo[1]) {
+    iy = static_cast<int> ((x[1]-bboxlo[1])*bininvy);
+    iy = std::min(iy,nbiny-1);
+  } else
+    iy = static_cast<int> ((x[1]-bboxlo[1])*bininvy) - 1;
+
+  if (x[2] >= bboxhi[2])
+    iz = static_cast<int> ((x[2]-bboxhi[2])*bininvz) + nbinz;
+  else if (x[2] >= bboxlo[2]) {
+    iz = static_cast<int> ((x[2]-bboxlo[2])*bininvz);
+    iz = std::min(iz,nbinz-1);
+  } else
+    iz = static_cast<int> ((x[2]-bboxlo[2])*bininvz) - 1;
+
+  return (iz-mbinzlo)*mbiny*mbinx + (iy-mbinylo)*mbinx + (ix-mbinxlo);
+}

--- a/src/region_neighbor_list.h
+++ b/src/region_neighbor_list.h
@@ -1,0 +1,88 @@
+/* ----------------------------------------------------------------------
+   LIGGGHTS - LAMMPS Improved for General Granular and Granular Heat
+   Transfer Simulations
+
+   Copyright 2014-     JKU Linz
+
+   LIGGGHTS is based on LAMMPS
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author:
+   Richard Berger (JKU Linz)
+------------------------------------------------------------------------- */
+
+#ifndef REGION_NEIGHBOR_LIST_H
+#define REGION_NEIGHBOR_LIST_H
+
+#include <vector>
+#include "vector_liggghts.h"
+#include "bounding_box.h"
+
+namespace LIGGGHTS {
+
+/**
+ * @brief A small particle structure
+ */
+struct Particle {
+  double x[3];
+  double radius;
+
+  Particle(double * pos, double rad) {
+    LAMMPS_NS::vectorCopy3D(pos, x);
+    radius = rad;
+  }
+};
+
+
+/**
+ * @brief A neighbor list of of a certain region
+ *
+ * This implementation uses the same binning approach used in LAMMPS neighbor lists.
+ * Instead of accessing internal data structures directly, manipulations and queries
+ * can only occur through the given interface.
+ */
+class RegionNeighborList
+{
+  typedef std::vector<Particle> ParticleBin;
+
+  std::vector<ParticleBin> bins;  // list of particle bins
+  std::vector<int> stencil;       // stencil used to check bins for collisions
+  size_t ncount;                  // total number of particles in neighbor list
+
+  double bboxlo[3];               // lowest point of bounding box
+  double bboxhi[3];               // highest point of bounding box
+
+  int nbinx,nbiny,nbinz;          // # of global bins
+  int mbinx,mbiny,mbinz;          // # of bins in each dimension
+  int mbinxlo,mbinylo,mbinzlo;    // offsets of (0,0,0) bin
+
+  double binsizex,binsizey,binsizez;  // bin sizes
+  double bininvx,bininvy,bininvz;     // inverse of bin sizes
+
+  double bin_distance(int i, int j, int k);
+  int coord2bin(double *x) const;
+
+public:
+    RegionNeighborList();
+
+    bool hasOverlap(double * x, double radius) const;
+    void insert(double * x, double radius);
+    size_t count() const;
+    void reset();
+    bool setBoundingBox(LAMMPS_NS::BoundingBox & bb, double maxrad);
+};
+
+}
+
+#endif // REGION_NEIGHBOR_LIST_H


### PR DESCRIPTION
The current insertion algorithm exhibits poor scaling performance with a runtime complexity of O(n²). This is due to the fact that during each time step a utility data structure is build up to hold any particles which might collide with newly inserted particles. If a large number of particles is inserted this linear list of particles will grow accordingly. E.g. if 3 million particles are inserted, the last particle will check 2,999,999 particles for possible overlap.

To improve this situation, this PR introduces a cell list data structure around the insertion volume to replace the linear list of particles. This reduces lookup times during overlap checking.

The PR also includes a simple benchmark test case which can be used to compare the scaling of the old and the new version of the code. This test case simply inserts a specified number of particles into the domain box. The tests ranged from 10,000 - 150,000 particles. As the number of particles increases the achieved speedup of the optimized code continues to grow due to the better
runtime complexity. With a serial run (Intel Core i7-3770) of inserting 150,000 particles into a box a **speedup of 76x was observed**.

The full scaling change is summarized by the following Figure. While the old code exhibits O(n²) runtime complexity, the optimized variant shows nearly linear scaling. Notice the differences in order of magnitude in the run times of the first two graphs. In the final plot both results are merged into one graph.

![insertion_opt_data](https://cloud.githubusercontent.com/assets/2828630/8798965/b1cbad0e-2fa6-11e5-89f7-2419a643caeb.png)
